### PR TITLE
Fix t\complete_program.t failure on Windows

### DIFF
--- a/t/complete_program.t
+++ b/t/complete_program.t
@@ -17,23 +17,23 @@ sub mkexe { write_file($_[0], ""); chmod 0755, $_[0] }
 my $dir = tempdir(CLEANUP=>1);
 mkdir("$dir/dir1");
 mkdir("$dir/dir2");
-mkexe("$dir/dir1/prog1");
-mkexe("$dir/dir1/prog2");
-mkexe("$dir/dir2/prog3");
+mkexe("$dir/dir1/prog1.bat");
+mkexe("$dir/dir1/prog2.bat");
+mkexe("$dir/dir2/prog3.bat");
 
 {
     local $^O = 'linux';
     local $ENV{PATH} = "$dir/dir1:$dir/dir2";
-    is_deeply(complete_program(word=>"prog"), ["prog1","prog2","prog3"]);
-    is_deeply(complete_program(word=>"prog3"), ["prog3"]);
+    is_deeply(complete_program(word=>"prog"), ["prog1.bat","prog2.bat","prog3.bat"]);
+    is_deeply(complete_program(word=>"prog3"), ["prog3.bat"]);
     is_deeply(complete_program(word=>"prog9"), []);
 }
 
 subtest "win support" => sub {
     local $^O = 'MSWin32';
     local $ENV{PATH} = "$dir/dir1;$dir/dir2";
-    is_deeply(complete_program(word=>"prog"), ["prog1","prog2","prog3"]);
-    is_deeply(complete_program(word=>"prog3"), ["prog3"]);
+    is_deeply(complete_program(word=>"prog"), ["prog1.bat","prog2.bat","prog3.bat"]);
+    is_deeply(complete_program(word=>"prog3"), ["prog3.bat"]);
     is_deeply(complete_program(word=>"prog9"), []);
 };
 


### PR DESCRIPTION
On Windows, whether a file is "executable" is determined by file
extension -- chmod 0755 does not do it. A zero byte .BAT file is
a valid executable. On Unixy systems, all that matters are the
permissions bits, so my fix was to change the names of the files
created by the test script to `prog%d.bat`.

See also [test report](http://www.cpantesters.org/cpan/report/4ca56e4a-6c51-1014-9fae-659eb0a04611), and [my blog post](http://blog.nu42.com/2014/12/when-bits-dont-stick.html#complete-util-bug)
